### PR TITLE
Not freeing empty list

### DIFF
--- a/libusb.go
+++ b/libusb.go
@@ -896,6 +896,9 @@ func Free_Device_List(list []Device, unref_devices int) {
 	if list == nil {
 		return
 	}
+	if len(list) == 0 {
+		return
+	}
 	C.libusb_free_device_list((**C.struct_libusb_device)(&list[0]), C.int(unref_devices))
 }
 


### PR DESCRIPTION
When I was doing experiments with libusb, on Windows, I had issue with empty list. The expression

> (&list[0])

threw go exception at me. Adding this conditional fixed it. libusb_free_device_list doesn't do anything on empty array anyway, so it should be OK